### PR TITLE
Split path and source label to two rows

### DIFF
--- a/lib/ui/widgets/analogcomponent.js
+++ b/lib/ui/widgets/analogcomponent.js
@@ -97,8 +97,9 @@ module.exports = React.createClass({
 
           <text  y="-50" textAnchor="middle" fontSize="70" dominantBaseline="middle">
             <tspan x="0">{BaseWidget.prototype.displayValue(this.state.value)}</tspan>
-            <tspan x="0" dy="30" fontSize="30">{this.props.convertTo ? this.props.convertTo : this.props.unit}</tspan>
-            <tspan x="0" dy="30" fontSize="30">{this.props.label + " " + this.props.sourceId}</tspan>
+            <tspan x="0" dy="31" fontSize="30">{this.props.convertTo ? this.props.convertTo : this.props.unit}</tspan>
+              <tspan x="0" dy="30" fontSize="30">{this.props.label}</tspan>
+              <tspan x="0" dy="-125" fontSize="10">{this.props.sourceId}</tspan>
           </text>
 
         </g>

--- a/lib/ui/widgets/analogcomponent.js
+++ b/lib/ui/widgets/analogcomponent.js
@@ -97,7 +97,7 @@ module.exports = React.createClass({
 
           <text  y="-50" textAnchor="middle" fontSize="70" dominantBaseline="middle">
             <tspan x="0">{BaseWidget.prototype.displayValue(this.state.value)}</tspan>
-            <tspan x="0" dy="30" fontSize="30">-</tspan>
+            <tspan x="0" dy="30" fontSize="30">{this.props.convertTo ? this.props.convertTo : this.props.unit}</tspan>
             <tspan x="0" dy="30" fontSize="30">{this.props.label + " " + this.props.sourceId}</tspan>
           </text>
 

--- a/lib/ui/widgets/digitalcomponent.js
+++ b/lib/ui/widgets/digitalcomponent.js
@@ -26,8 +26,11 @@ module.exports = React.createClass({
   render: function() {
     return (
       <svg height="100%" width="100%" viewBox="0 0 20 40">
-        <text x="10" y="8" textAnchor="middle" fontSize="5" dominantBaseline="middle">
-          {this.props.label + " " + this.props.sourceId}
+        <text x="10" y="6" textAnchor="middle" fontSize="6" dominantBaseline="middle">
+          {this.props.label}
+        </text>
+        <text x="10" y="37" textAnchor="middle" fontSize="3" dominantBaseline="middle">
+          {this.props.sourceId}
         </text>
         <g transform="translate(10, 0)">
           <text textAnchor="middle" y="32" fontSize="26" dominantBaseline="middle">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,5 +33,5 @@ module.exports = {
     new webpack.NoErrorsPlugin(),
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)
   ],
-  externals: ['mdns', 'validator-js']
+  externals: ['mdns', 'validator-js', 'ws']
 }


### PR DESCRIPTION
With longer SK paths and source names the label was getting really long and ugly. This PR splits the information to two rows.
