### PR TITLE
fix (build): define ws as external

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,5 +33,5 @@ module.exports = {
     new webpack.NoErrorsPlugin(),
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)
   ],
-  externals: ['mdns', 'validator-js']
+  externals: ['mdns', 'validator-js', 'ws']
 }


### PR DESCRIPTION
Browser WebSocket is always used, so we can safely ignore the `ws` dependency of signalk-client.