### PR TITLE
Create widgets in multiple columns by default

### DIFF
--- a/lib/ui/instrumentpanel.js
+++ b/lib/ui/instrumentpanel.js
@@ -109,7 +109,7 @@ InstrumentPanel.prototype.handlePossiblyNewSource = function(newSource) {
     this.getWidgets().push(widget);
     var initialDimensions = widget.getInitialDimensions();
     this.getLayout().unshift({
-      "w": initialDimensions.w,
+      "w": 2,
       "h": initialDimensions.h,
       "x": getColumnforPath(newSource.path) * 2,
       "y": 0,

--- a/lib/ui/instrumentpanel.js
+++ b/lib/ui/instrumentpanel.js
@@ -111,7 +111,7 @@ InstrumentPanel.prototype.handlePossiblyNewSource = function(newSource) {
     this.getLayout().unshift({
       "w": initialDimensions.w,
       "h": initialDimensions.h,
-      "x": 0,
+      "x": getColumnforPath(newSource.path) * 2,
       "y": 0,
       "i": this.getLayout().length + ''
     });
@@ -203,6 +203,22 @@ InstrumentPanel.prototype.connected = function(host) {
   } else {
     this.setWidgetData(browser.retrieveGrid(host));
   }
+}
+
+
+const columnsForPaths = {
+  navigation: 0,
+  environment: 1
+}
+
+function getColumnforPath(path) {
+  const group = path.split('.')[0]
+  let column = columnsForPaths[group]
+  if (typeof column === "undefined") {
+    column = Object.keys(columnsForPaths).length
+    columnsForPaths[group] = column
+  }
+  return column
 }
 
 module.exports = InstrumentPanel;

--- a/lib/ui/widgets/basewidget.js
+++ b/lib/ui/widgets/basewidget.js
@@ -14,7 +14,7 @@ function BaseWidget(id, options, streamBundle, instrumentPanel) {
 }
 
 BaseWidget.prototype.getInitialDimensions = function() {
-  return {w: 2, h: 2};
+  return {h: 2};
 }
 
 BaseWidget.prototype.getReactElement = function() {

--- a/lib/ui/widgets/compass.js
+++ b/lib/ui/widgets/compass.js
@@ -78,7 +78,7 @@ Compass.prototype.getOptions = function() {
 }
 
 Compass.prototype.getInitialDimensions = function() {
-  return {w:2, h:4};
+  return {h:4};
 }
 
 module.exports = {

--- a/lib/ui/widgets/digitalposition.js
+++ b/lib/ui/widgets/digitalposition.js
@@ -56,7 +56,7 @@ DigitalPosition.prototype.getOptions = function() {
 }
 
 DigitalPosition.prototype.getInitialDimensions = function() {
-  return {w:2, h:3};
+  return {h:3};
 }
 
 

--- a/lib/ui/widgets/linear.js
+++ b/lib/ui/widgets/linear.js
@@ -1,0 +1,94 @@
+var React = require('react');
+var d3 = require('d3');
+
+var gaugeComponents = require('./gaugecomponents');
+var getShadow = gaugeComponents.getShadow;
+var getHand = gaugeComponents.getHand;
+var BaseWidget = require('./basewidget');
+
+var size = 400;
+var half = size / 2;
+var strokeWidth = 25;
+
+module.exports = React.createClass({
+  getInitialState: function() {
+    return {
+      value: 0,
+      label: this.props.label,
+      minValue: this.props.minValue || 0,
+      maxValue: this.props.maxValue || 10
+    };
+  },
+
+  renderTicks: function(scale) {
+    var yOffset = 0;
+    return scale.ticks().map(function(i) {
+      return (
+    <g key={"text-" + i} transform={'rotate(' + scale(i) + ' 200 0)'}>
+      <text x={-half} y={yOffset + 10} textAnchor="middle" dominantBaseline="central" style={{"fontSize":"28px"}}
+        transform={"rotate(" + -scale(i) + ")"}>{i}</text>
+    </g>
+)
+    });
+  },
+
+  render: function() {
+    try {
+    var scale = d3.scale.linear()
+       .domain([this.state.minValue, this.state.maxValue])
+       .range([0, size]).clamp(true);
+    var logScale = d3.scale.log()
+    .base(Math.E)
+    .domain([Math.max(this.state.minValue, 0.00001), this.state.maxValue])
+    .range([0, size]).clamp(true)
+
+
+    return (
+      <svg height="100%" width="100%" viewBox={"0 0 " + size/4 + " " + size}>
+        <g stroke="black">
+        <rect x="0" y="0" width="100" height={scale(this.state.value)} transform="translate(0,400) scale(1,-1)"/>
+        <rect x="100" y="0" width="100" height={logScale(this.state.value)} transform="translate(0,400) scale(1,-1)"/>
+        </g>
+      </svg>
+    )
+  } catch (ex) {
+    console.log(ex)
+  }
+  return (<div>failsafe</div>)
+  },
+
+  componentDidMount: function() {
+    this.unsubscribes = [];
+    if (this.props.valueStream) {
+      this.unsubscribes.push(this.props.valueStream.onValue(function(value) {
+        if (typeof value === 'number') {
+          this.setState({
+            value: value
+          });
+        }
+      }.bind(this)));
+    }
+    this.unsubscribes.push(this.props.maxValueStream.onValue(function(value) {
+      this.setState({
+        maxValue: value
+      });
+    }.bind(this)));
+    this.unsubscribes.push(this.props.minValueStream.onValue(function(value) {
+      this.setState({
+        minValue: value
+      });
+    }.bind(this)));
+    this.unsubscribes.push(this.props.redLineStream.onValue(function(value) {
+      this.setState({
+        redLine: value
+      });
+    }.bind(this)));
+  },
+
+
+  componentWillUnmount: function() {
+    this.unsubscribes.forEach(function(unsubscribe) {
+      unsubscribe()
+    });
+  }
+});

--- a/lib/ui/widgets/windmeter.js
+++ b/lib/ui/widgets/windmeter.js
@@ -141,7 +141,7 @@ function WindMeter(id, options, streamBundle, instrumentPanel) {
   BaseWidget.call(this, id, options, streamBundle, instrumentPanel);
   this.options = options;
   this.options.activeSources = {};
-  this.options.initialDimensions = this.options.initialDimensions || {w: 2, h: 4};
+  this.options.initialDimensions = this.options.initialDimensions || {h: 4};
   this.active = true;
 
   // no-op setState to disable updates of deserialized but currently unmounted


### PR DESCRIPTION
Create widgets in multiple columns so that the initial layout is not just a single really long column. 

Widgets are grouped by SK path prefix: the first column is navigation, the second is environment and after that columns are created on the fly, depending on the incoming data.

Resolves #40 