### PR TITLE
fix: bad position of icon on clickable widget in setting mode (chrome browser)

### DIFF
--- a/dist/css/settingslist.css
+++ b/dist/css/settingslist.css
@@ -17,10 +17,15 @@ div.widget svg {
 	margin-left: 10px;
 	margin-top: 10px;
 }
-.clickIconWidget {
-  left: 5;
-  top: 5;
+div.react-grid-item .clickIconWidget {
+  left: 5px;
+  top: 5px;
   position: absolute;
+}
+div.widget .clickIconWidget {
+  left: 5px;
+  top: -15px;
+  position: relative;
 }
 @media (min-width: 620px) {
   .items .item {


### PR DESCRIPTION
Partial fix the bad position of icon on clickable widget in setting mode.

- This solve for chrome browser.
- In firefox browser, icon is simply not displayed  👎
- May be fixed with an update of the React version in the future.
