### PR TITLE
feature: check outdated widgets before loading layout

### DIFF
--- a/lib/ui/instrumentpanel.js
+++ b/lib/ui/instrumentpanel.js
@@ -141,14 +141,21 @@ InstrumentPanel.prototype.setWidgetData = function(widgetData) {
 
 InstrumentPanel.prototype.deserializeWidget = function(oneWidgetData, i) {
   var module = widgetModulesByType[oneWidgetData.type];
-  if (!module) {
-    console.error("Could not find widget for " + JSON.stringify(oneWidgetData));
-    return new widgetModules[0].constructor(i, {
-      path: 'error'
-    }, this.streamBundle);
+  var updatedModule = widgetModuleFor(oneWidgetData.options.path) || widgetModules[0];
+  if (oneWidgetData.type !== updatedModule.type) {
+    console.warn("Module type:'" + oneWidgetData.type + "' is outdated, module type :'" +
+      updatedModule.type + "' will be used instead");
+    console.warn("widget details:" + JSON.stringify(oneWidgetData));
+    module = updatedModule;
+  }
+  if (typeof oneWidgetData.options === 'undefined') {
+    oneWidgetData.options = {};
   }
   if (typeof oneWidgetData.options.active === 'undefined') {
     oneWidgetData.options.active = true;
+  }
+  if (typeof oneWidgetData.options.path === 'undefined') {
+    oneWidgetData.options.path = 'error';
   }
   var widget = new module.constructor(i, oneWidgetData.options, this.streamBundle, this);
   return widget;


### PR DESCRIPTION
feature: check outdated widgets before loading layout
- On loading layout, the widget type is checked in the widget database.
- if it's outdated, it's replaced with the new one.
- If it's unknown widget, the universal widget is used.