### PR TITLE
feature: add popup if no wind true data

### DIFF
--- a/lib/ui/widgets/windmeter.js
+++ b/lib/ui/widgets/windmeter.js
@@ -201,6 +201,7 @@ class ComponentClass extends React.Component {
     super(props);
     this.state = {
       displayModeIndex: this.props.options.displayModeIndex,
+      popupRaised: 0
     };
     this.changeDisplayMode = this.changeDisplayMode.bind(this);
   }
@@ -217,6 +218,20 @@ class ComponentClass extends React.Component {
 
   changeDisplayMode() {
     const newDisplayModeIndex = getNextDisplayModeIndex(this.state.displayModeIndex);
+    const bitmaskIndex = 1 << newDisplayModeIndex;
+    if ((newDisplayModeIndex !== 0) && !(this.state.popupRaised & bitmaskIndex)) {
+      const activeSources = this.props.options.activeSources;
+      const pathFound = Object.keys(activeSources).filter(function(key) {
+        return ((activeSources[key].path === pathsCovered[newDisplayModeIndex]) || // check for wind angle path
+          (activeSources[key].path === pathsCovered[newDisplayModeIndex + 3]) // check for wind speed path
+        )})
+      if (pathFound.length != 2) {
+        alert("Your system seems to be missing " + getValuesForDisplayModeIndex[newDisplayModeIndex](this.props.values).label +
+          ".\nYou can try installing the Derived Data plugin,\n" +
+          "and activating \"Ground Wind Angle\" & \"Speed True Wind Angle\".");
+        this.setState({ popupRaised: this.state.popupRaised | bitmaskIndex}); //popup raised only once by mode
+      }
+    }
     this.setState({ displayModeIndex: newDisplayModeIndex});
     this.props.options.displayModeIndex = newDisplayModeIndex;
     this.props.instrumentPanel.persist();


### PR DESCRIPTION
feature: add popup if no wind true data
When you clic on windmeter widget if your system seems to be missing true wind, a popup message is raised to invite the user to try installing the Derived Data plugin, and activating "Ground  Wind Angle" & "Speed True Wind Angle" fonctionallity.