### PR TITLE
chore: add the new widgets by page bottom

### DIFF
--- a/lib/ui/widgets/basewidget.js
+++ b/lib/ui/widgets/basewidget.js
@@ -45,7 +45,7 @@ BaseWidget.prototype.setInitialLayout = function(layout) {
         "w": initialDimensions.w,
         "h": initialDimensions.h,
         "x": this.instrumentPanel.getColumnforPath(this.options.path) * 2,
-        "y": 0,
+        "y": Infinity,
         "i": this.id.toString()
        };
     }


### PR DESCRIPTION
chore: add the new widgets by page bottom
To avoid breaking the existing layout, the new discovered widgets are add by page bottom.