### PR TITLE
chore: rewriting toolTips code

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,6 @@
       width: 100%;
       height: auto;
       background-color: inherit;
-      white-space: pre;
     }
 
     .tooltips-hide {

--- a/lib/ui/instrumentpanel.js
+++ b/lib/ui/instrumentpanel.js
@@ -76,12 +76,6 @@ InstrumentPanel.prototype.setPage = function(page) {
     this.populateNewPage(page);
   }
   this.currentPage = page;
-  document.getElementsByName('tooltips').forEach( (element) => {
-    if (element.className.includes('tooltips-show')) {
-      element.className = 'tooltips-base tooltips-hide';
-      element.textContent = '';
-    }
-  })
   this.sortNotificationLayout();
   this.pushGridChanges();
 }
@@ -99,7 +93,7 @@ InstrumentPanel.prototype.populateNewPage = function(page) {
         var module = widgetModuleFor(existingWidget.options.path) || widgetModules[0];
         var newOptions = Object.assign({}, existingWidget.options);
         newOptions.active = true;
-        var newWidget = new module.constructor(that.pages[newPage].widgets.length,
+        var newWidget = new module.constructor(newPage + '-' + that.pages[newPage].widgets.length,
           newOptions, that.streamBundle, that);
         that.pages[newPage].widgets.push(newWidget);
       }
@@ -175,7 +169,7 @@ InstrumentPanel.prototype.handlePossiblyNewSource = function(newSource) {
   }
 
   if (!handled) {
-    var widget = new module.constructor(this.getWidgets(handlePage).length, {
+    var widget = new module.constructor(handlePage + '-' + this.getWidgets(handlePage).length, {
       sourceId: newSource.sourceId,
       key: newSource.key,
       path: newSource.path,
@@ -206,7 +200,7 @@ InstrumentPanel.prototype.serializableSettings = function() {
 InstrumentPanel.prototype.setWidgetData = function(widgetData) {
   var that = this;
   if (widgetData && widgetData.pages) {
-    this.pages = widgetData.pages.map(function(page) {
+    this.pages = widgetData.pages.map(function(page, pageID) {
       if (typeof page.widgets !== 'undefined') {
         for (const [key, widget] of page.widgets.entries()) {
           if ((widget.type === 'notification') || ( new RegExp('^notifications\.').test(widget.options.path))) {
@@ -216,8 +210,8 @@ InstrumentPanel.prototype.setWidgetData = function(widgetData) {
         }
       }
       return {
-        layout: page.layout,
-        widgets: page.widgets.map(that.deserializeWidget.bind(that)),
+        layout: page.layout.map(that.updateLayoutFormat.bind(that, pageID)),
+        widgets: page.widgets.map(that.deserializeWidget.bind(that, pageID)),
         knownKeys: page.knownKeys
       }
     });
@@ -226,7 +220,12 @@ InstrumentPanel.prototype.setWidgetData = function(widgetData) {
   }
 }
 
-InstrumentPanel.prototype.deserializeWidget = function(oneWidgetData, i) {
+InstrumentPanel.prototype.updateLayoutFormat = function(pageID, layout) {
+  if (typeof layout.i === 'number') {layout.i = pageID + '-' + layout.i}
+  return layout;
+}
+
+InstrumentPanel.prototype.deserializeWidget = function(pageID, oneWidgetData, i) {
   var module = widgetModulesByType[oneWidgetData.type];
   var updatedModule = widgetModuleFor(oneWidgetData.options.path) || widgetModules[0];
   if (oneWidgetData.type !== updatedModule.type) {
@@ -244,7 +243,7 @@ InstrumentPanel.prototype.deserializeWidget = function(oneWidgetData, i) {
   if (typeof oneWidgetData.options.path === 'undefined') {
     oneWidgetData.options.path = 'error';
   }
-  var widget = new module.constructor(i, oneWidgetData.options, this.streamBundle, this);
+  var widget = new module.constructor(pageID + '-' + i, oneWidgetData.options, this.streamBundle, this);
   return widget;
 }
 
@@ -276,7 +275,7 @@ InstrumentPanel.prototype.getActiveWidgets = function() {
     if (typeof layout === 'undefined') {
       layout = widget.getInitialLayout();
     }
-    return {layout: layout, reactWidget: widget.getReactElement()};
+    return {layout: layout, reactWidget: widget.getReactElement(), toolTips: widget.toolTips};
   });
   return result;
 }
@@ -324,9 +323,24 @@ InstrumentPanel.prototype.connected = function(host) {
 InstrumentPanel.prototype.sortNotificationLayout = function() {
   var widgets = this.getEnabledWidgets(notificationPageId);
   var oldLayout = this.notificationPage.layout;
+  if (oldLayout.length === 0) {
+    var yOffset = 0;
+    widgets.forEach( widget => {
+      oldLayout.push({
+        w: 100,
+        h: 2,
+        x: 0,
+        y: yOffset,
+        i: widget.id,
+        moved: false,
+        static: false
+      })
+      yOffset *=2
+    })
+  }
   var newLayout = oldLayout.sort(function (item1, item2) {
-    var id1 = parseInt(item1.i);
-    var id2 = parseInt(item2.i);
+    var id1 = item1.i;
+    var id2 = item2.i;
     var widget1 = widgets.find(widget => widget.id === id1);
     var widget2 = widgets.find(widget => widget.id === id2);
     if ((typeof widget1 !== 'undefined') && (typeof widget2 !== 'undefined')) {
@@ -342,7 +356,9 @@ InstrumentPanel.prototype.sortNotificationLayout = function() {
   this.notificationPage.layout = newLayout;
 }
 
-InstrumentPanel.prototype.updateNotificationLevel = function() {
+InstrumentPanel.prototype.updateNotificationLevel = function(levelChange) {
+  if (typeof levelChange === 'undefined') {levelChange = false}
+  var mustPushGridChanges = false;
   var newLevelEnabled;
   var newLevelDisabled;
   var widgets = this.getEnabledWidgets(notificationPageId);
@@ -381,6 +397,9 @@ InstrumentPanel.prototype.updateNotificationLevel = function() {
     this.notificationColor = this.notificationColors[this.notificationLevel];
     this.notificationLevelHidden = newLevelDisabled;
     this.notificationColorHidden = this.notificationColors[this.notificationLevelHidden];
+    mustPushGridChanges = true;
+  }
+  if (mustPushGridChanges || (levelChange && this.currentPage === notificationPageId)) {
     this.pushGridChanges();
   }
 }

--- a/lib/ui/main.js
+++ b/lib/ui/main.js
@@ -13,6 +13,7 @@ import HelpComponent from '../util/help';
 
 var streamBundle = new StreamBundle();
 var instrumentPanel = new InstrumentPanel(streamBundle);
+const notificationPageId = -1;
 
 var model = BaconModel.Model.combine({
   isLocked: BaconModel.Model(true),
@@ -27,54 +28,11 @@ class App extends React.Component {
   constructor(props) {
     super(props);
     this.state = this.props.model.get();
+    this.wrapWidget = this.wrapWidget.bind(this);
+    this.generateClickmeElement  = this.generateClickmeElement.bind(this);
   }
 
   render() {
-    var isLocked = this.state.isLocked;
-    var widgetSelected = this.state.widgetSelected;
-    var wrapInDiv = function(widget, i) {
-      function toolTipsHideShow(event) {
-        if (event.currentTarget.textContent !== '') {
-          event.currentTarget.className = 'tooltips-base tooltips-hide';
-          event.currentTarget.textContent = '';
-        } else {
-          var sourceId = '';
-          if (typeof widget.reactWidget.props.options !== 'undefined') {
-            if (typeof widget.reactWidget.props.options.activeSources !== 'undefined') { // windmeter
-              sourceId = Object.values(widget.reactWidget.props.options.activeSources).reduce(
-                (acc, source) => {
-                  var pathArray = source.path.split('.');
-                  return acc + pathArray[pathArray.length -1] + ':' + source.sourceId + '\r\n';
-                }, '');
-            } else if (typeof widget.reactWidget.props.options !== 'undefined') { // compass,attitude,digitaldatetime,digitalposition
-              sourceId = widget.reactWidget.props.options.sourceId;
-            }
-          }  else { // universal
-            sourceId = widget.reactWidget.props.sourceId;
-          }
-          event.currentTarget.className = 'tooltips-base tooltips-show';
-          event.currentTarget.textContent = 'sourceId:\r\n' + sourceId;
-        }
-      };
-
-      var divTooltips = (isLocked)? React.createElement('div', {name: 'tooltips', className: 'tooltips-base', onClick: toolTipsHideShow}) : null;
-      var divClickme = (isLocked && widget.reactWidget.props.withClickMe) ? React.createElement('div', {className: 'widget-clickme'}): null;
-      var divStyle = {};
-      if (typeof widget.reactWidget.props.notification !== 'undefined') {
-        divStyle.borderColor = widget.reactWidget.props.notification.value.color;
-        divStyle.borderWidth = (widget.reactWidget.props.notification.value.level) ? '2px' : '1px';
-      } else {
-        divStyle.borderColor = widget.reactWidget.props.instrumentPanel.notificationColor;
-        divStyle.borderWidth = (widget.reactWidget.props.instrumentPanel.notificationLevel) ? '2px' : '1px';
-      }
-
-      return React.createElement('div', {style: divStyle, key: widget.reactWidget.key, 'data-grid': widget.layout },
-        widget.reactWidget,
-        divTooltips,
-        divClickme
-      );
-    };
-
     var width = window.innerWidth
       || document.documentElement.clientWidth
       || document.body.clientWidth;
@@ -84,7 +42,7 @@ class App extends React.Component {
       || document.body.clientHeight;
 
 // https://github.com/STRML/react-grid-layout/issues/382#issuecomment-299734450
-    let newLayout = (instrumentPanel.currentPage !== -1) ? this.state.gridSettings.layout :
+    let newLayout = (instrumentPanel.currentPage !== notificationPageId) ? this.state.gridSettings.layout :
       JSON.parse(JSON.stringify(this.state.gridSettings.layout));
 
     return (
@@ -99,7 +57,7 @@ class App extends React.Component {
             className="layout"
             margin= {[5, 5]}
             layout={newLayout}
-            children={this.state.gridSettings.activeWidgets.map(wrapInDiv)}
+            children={this.generateGridChildren()}
             cols={Math.round(width/320*2)}
             rowHeight={40}
             isDraggable={!this.state.isLocked}
@@ -129,6 +87,117 @@ class App extends React.Component {
     // Disable touch scrolling while dragging on mobile devices (iOS12).
     e.target.ontouchmove = function(){ return false; };
   };
+
+  generateGridChildren() {
+    var isLocked = this.state.isLocked;
+    var that = this;
+    return this.state.gridSettings.activeWidgets.map(widget => {
+      return that.wrapWidget(widget)
+    });
+  }
+
+  wrapWidget(widget) {
+    var wrapperStyle = {};
+    if (typeof widget.reactWidget.props.notification !== 'undefined') {
+      wrapperStyle.borderColor = widget.reactWidget.props.notification.value.color;
+      wrapperStyle.borderWidth = (widget.reactWidget.props.notification.value.level) ? '2px' : '1px';
+    } else {
+      wrapperStyle.borderColor = instrumentPanel.notificationColor;
+      wrapperStyle.borderWidth = (instrumentPanel.notificationLevel) ? '2px' : '1px';
+    }
+    if (widget.toolTips()) {wrapperStyle.zIndex = 1;}
+    return React.createElement(
+      'div',
+      {
+        style: wrapperStyle,
+        key: widget.reactWidget.key,
+        'data-grid': widget.layout
+      },
+      widget.reactWidget,
+      this.generateToolTipsElement(widget),
+      this.generateClickmeElement(widget)
+    );
+  }
+
+  generateToolTipsElement(widget) {
+    class ToolTipsComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          toolTipsVisible: this.props.widget.toolTips() || false
+        };
+        this.toolTipsHideShow = this.toolTipsHideShow.bind(this);
+      }
+
+      render() {
+        if (!this.props.isLocked) { return null }
+        return React.createElement(
+          'div',
+          {
+            key: this.props.id,
+            className: 'tooltips-base ' + ((this.state.toolTipsVisible) ? 'tooltips-show' : 'tooltips-hide'),
+            onClick: this.toolTipsHideShow,
+            dangerouslySetInnerHTML: {__html: this.toolTipsContent(widget)}
+          }
+        )
+      }
+
+      toolTipsContent(widget) {
+        var sourceIdContent = '';
+        if (this.state.toolTipsVisible) {
+          if (typeof this.props.widget.reactWidget.props.options !== 'undefined') {
+            if (typeof this.props.widget.reactWidget.props.options.activeSources !== 'undefined') {
+              // widget type: windmeter
+              sourceIdContent = Object.values(this.props.widget.reactWidget.props.options.activeSources).reduce(
+                (acc, source) => {
+                  var pathArray = source.path.split('.');
+                  return acc + pathArray[pathArray.length -1] + ': ' + source.sourceId + '<br>';
+                },
+                ''
+              );
+            } else if (typeof this.props.widget.reactWidget.props.options !== 'undefined') {
+                // widget type: compass,attitude,digitaldatetime,digitalposition
+                sourceIdContent = this.props.widget.reactWidget.props.options.sourceId;
+              }
+          } else {
+              // widget type: universal
+              sourceIdContent = this.props.widget.reactWidget.props.sourceId;
+            }
+          sourceIdContent = '<b>sourceId:</b><br>' + sourceIdContent;
+        }
+        return sourceIdContent;
+      }
+
+      toolTipsHideShow() {
+        this.setState({
+          toolTipsVisible: !this.state.toolTipsVisible
+        })
+        this.props.widget.toolTips(true);
+        this.props.widget.reactWidget.props.instrumentPanel.pushGridChanges();
+      }
+    }
+
+    return React.createElement(ToolTipsComponent,{
+      id: 't' + widget.reactWidget.key,
+      widget: widget,
+      isLocked: this.state.isLocked
+    });
+  }
+
+  generateClickmeElement(widget) {
+    if (
+      !widget.reactWidget.props.withClickMe ||
+      !this.state.isLocked
+    ) { return null }
+    return React.createElement(
+      'div',
+      {
+        key: instrumentPanel.currentPage + 'c' + widget.reactWidget.key,
+        className: 'widget-clickme'
+      }
+    );
+  }
+
 };
 
 App.propTypes = {

--- a/lib/ui/navbar.js
+++ b/lib/ui/navbar.js
@@ -228,6 +228,9 @@ export default class IpNavBar extends React.Component {
   }
 
   setPage(page) {
+    if (page === notificationPageId) {
+      this.props.model.lens("isLocked").set(true);
+    }
     this.props.instrumentPanel.setPage(page);
   }
 

--- a/lib/ui/settings/settingspanel.js
+++ b/lib/ui/settings/settingspanel.js
@@ -6,6 +6,8 @@ import GridJson from './gridjson';
 import InstrumentPanel from '../instrumentpanel';
 import WidgetList from './widgetlist';
 
+const notificationPageId = -1;
+
 export default class SettingsPanel extends React.Component {
   constructor(props) {
     super(props);
@@ -61,12 +63,20 @@ export default class SettingsPanel extends React.Component {
 
   hideAll() {
     this.props.instrumentPanel.getWidgets().forEach( widget => widget.options.active = false);
-    this.props.instrumentPanel.pushGridChanges();
+    if (this.props.instrumentPanel.currentPage === notificationPageId) {
+      this.props.instrumentPanel.updateNotificationLevel(false)
+    } else {
+        this.props.instrumentPanel.pushGridChanges();
+      }
   }
 
   showAll() {
     this.props.instrumentPanel.getWidgets().forEach( widget => widget.options.active = true);
-    this.props.instrumentPanel.pushGridChanges();
+    if (this.props.instrumentPanel.currentPage === notificationPageId) {
+      this.props.instrumentPanel.updateNotificationLevel(false)
+    } else {
+        this.props.instrumentPanel.pushGridChanges();
+      }
   }
 
 };

--- a/lib/ui/settings/widgetrow.js
+++ b/lib/ui/settings/widgetrow.js
@@ -13,6 +13,8 @@ import PropTypes from 'prop-types';
 
 import BaseWidget from '../widgets/basewidget';
 
+const notificationPageId = -1;
+
 export default class WidgetRow extends React.Component {
   constructor(props) {
     super(props);
@@ -51,7 +53,11 @@ export default class WidgetRow extends React.Component {
 
   toggleActive() {
     this.props.widget.setActive(!this.props.widget.options.active);
-    this.props.widget.instrumentPanel.updateNotificationLevel();
+    if (this.props.instrumentPanel.currentPage === notificationPageId) {
+      this.props.instrumentPanel.updateNotificationLevel(false)
+    } else {
+        this.props.instrumentPanel.pushGridChanges();
+      }
   }
 };
 

--- a/lib/ui/widgets/basewidget.js
+++ b/lib/ui/widgets/basewidget.js
@@ -21,6 +21,8 @@ export default function BaseWidget(id, options, streamBundle, instrumentPanel) {
   this.streamBundle = streamBundle;
   this.instrumentPanel = instrumentPanel;
   this.setInitialLayout();
+  this.toolTipsVisible = false;
+  this.toolTips = this.toolTips.bind(this);
 }
 
 BaseWidget.prototype.getInitialDimensions = function() {
@@ -46,7 +48,7 @@ BaseWidget.prototype.setInitialLayout = function(layout) {
         "h": initialDimensions.h,
         "x": this.instrumentPanel.getColumnforPath(this.options.path) * 2,
         "y": Infinity,
-        "i": this.id.toString()
+        "i": this.id
        };
     }
   }
@@ -138,4 +140,11 @@ BaseWidget.prototype.updateUnitData = function(widget) {
     widget.instrumentPanel.persist();
     widget.updateStream(widget, valueStream);
   })
+}
+
+BaseWidget.prototype.toolTips = function(toggleVisible) {
+  if (toggleVisible) {
+    this.toolTipsVisible = !this.toolTipsVisible;
+  }
+  return this.toolTipsVisible;
 }

--- a/lib/ui/widgets/notification.js
+++ b/lib/ui/widgets/notification.js
@@ -27,19 +27,23 @@ function Notification(id, options, streamBundle, instrumentPanel) {
     }
   };
   this.streamBundle.getStreamForSourcePath(options.sourceId, options.path).onValue(function(value) {
+    var levelChange = false;
+    var oldLevel;
     if (value === null){
       value = {
         state: 'nominal',
         message: 'no alarm',
         timestamp: '',
-        date: null
+        date: null,
+        level: 0
       }
     }
     this.notification.value = value;
+    oldLevel = this.notification.value.level || 0;
     this.notification.value.level = notificationLevels[this.notification.value.state];
     this.notification.value.color = this.instrumentPanel.notificationColors[this.notification.value.level];
     this.notification.value.date = new Date(this.notification.value.timestamp);
-    this.instrumentPanel.updateNotificationLevel();
+    this.instrumentPanel.updateNotificationLevel(oldLevel !== this.notification.value.level);
     return value;
   }.bind(this))
   class NotificationComponent extends React.Component {


### PR DESCRIPTION
- Rewriting toolTips code with a react component.
- When you click on the top right corner of a widget to display the toolTips, the vertical size of the toolTips can now exceed the size of the widget and display more informations.
- Easier management to add content to the toolTips
- Blocking of widget size changes in the notification tab.
- Optimization of widget refresh in case of alarm level change.
- Modification of the widget ID to be unique in all pages (Id => PageNumber-Id).
- Updating the layout format when loading an old one saved configuration.
