### PR TITLE
fix: updateNotificationLevel & pushGridChanges in toggleActive

### DIFF
--- a/lib/ui/settings/widgetrow.js
+++ b/lib/ui/settings/widgetrow.js
@@ -53,10 +53,10 @@ export default class WidgetRow extends React.Component {
 
   toggleActive() {
     this.props.widget.setActive(!this.props.widget.options.active);
-    if (this.props.instrumentPanel.currentPage === notificationPageId) {
-      this.props.instrumentPanel.updateNotificationLevel(false)
+    if (this.props.widget.instrumentPanel.currentPage === notificationPageId) {
+      this.props.widget.instrumentPanel.updateNotificationLevel(false)
     } else {
-        this.props.instrumentPanel.pushGridChanges();
+        this.props.widget.instrumentPanel.pushGridChanges();
       }
   }
 };


### PR DESCRIPTION
fix bad reference in toggleActive() when updateNotificationLevel() or pushGridChanges()