### PR TITLE
chore: reduce the number of browser.saveGrid() calls

### DIFF
--- a/lib/ui/instrumentpanel.js
+++ b/lib/ui/instrumentpanel.js
@@ -61,6 +61,7 @@ export default function InstrumentPanel(streamBundle) {
   this.notificationColorHidden = this.notificationColors[0];
   this.gridSettingsModel = new BaconModel.Model("");
   this.pushGridChanges();
+  this.handleSaveLayoutDelay = null;
   var isUnkownKey = function(key) {
     return typeof this.getCurrentPage().knownKeys[key] === 'undefined';
   }.bind(this)
@@ -261,7 +262,14 @@ InstrumentPanel.prototype.onWidgetChange = function(widget) {
 
 InstrumentPanel.prototype.persist = function() {
   if (this.currentPage !== notificationPageId) {
-    browser.saveGrid(this.host, this.serializableSettings());
+    var that = this;
+    if (this.handleSaveLayoutDelay !== null) {
+      clearTimeout(this.handleSaveLayoutDelay);
+    }
+    this.handleSaveLayoutDelay = setTimeout(() => {
+      that.handleSaveLayoutDelay = null;
+      browser.saveGrid(that.host, that.serializableSettings());
+    }, 1000);
   }
 }
 


### PR DESCRIPTION
This pull request delays the call to `browser.saveGrid` to avoid repetitive calls.
- Before: for 34 widgets => 35 writes in the local storage at startup.
- After: 1 single call and 1 single writing. 
