### PR TITLE
fix: avoid clear entire localstorage

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,9 @@
   }
 
   if (getParameterByName('reset')) {
-    localStorage.clear();
+    localStorage.removeItem('signalkGrid3');
+    localStorage.removeItem('signalKHostConnected');
+    localStorage.removeItem('signalKLastHost');
     location.replace(location.protocol + '//' + location.host + location.pathname);
   }
   </script>

--- a/lib/ui/settings/settingspanel.js
+++ b/lib/ui/settings/settingspanel.js
@@ -60,7 +60,9 @@ export default class SettingsPanel extends React.Component {
 
   reset() {
     if (confirm("You will reset your entire layout")) {
-      localStorage.clear();
+      localStorage.removeItem('signalkGrid3');
+      localStorage.removeItem('signalKHostConnected');
+      localStorage.removeItem('signalKLastHost');
       location.reload();
     }
   }


### PR DESCRIPTION
Fixed a issue to avoid deleting all local storage when you reset the instrumentationpanel configuration.