### PR TITLE
chore: avoid searching for notification's meta

### DIFF
--- a/lib/ui/widgets/notification.js
+++ b/lib/ui/widgets/notification.js
@@ -73,7 +73,7 @@ function Notification(id, options, streamBundle, instrumentPanel) {
       return (
         <div style={{marginLeft: '5px'}}>
           <p>
-            [{this.props.label + '] ' + this.props.notification.value.state + ': '}
+            [{this.props.options.label + '] ' + this.props.notification.value.state + ': '}
             {(typeof this.props.notification.value.timestamp !== 'undefined') ? this.props.notification.value.timestamp + ': ' : ''}
             {this.props.notification.value.message}
           </p>
@@ -89,17 +89,9 @@ function Notification(id, options, streamBundle, instrumentPanel) {
     notification: this.notification,
     notificationStream: this.streamBundle
   });
-  this.updateUnitData(this);
 }
 
 util.inherits(Notification, BaseWidget);
-
-Notification.prototype.updateStream = function(widget, valueStream) {
-  widget.widget = React.cloneElement(widget.widget,{
-    label: widget.options.label.replace('notifications.',''),
-  })
-  widget.instrumentPanel.pushGridChanges();
-}
 
 Notification.prototype.getReactElement = function() {
   return this.widget;


### PR DESCRIPTION
avoid searching for metadata when notification path is discovered