### PR TITLE
feature: add additional paths to the digitaldatetime widget

### DIFF
--- a/lib/ui/widgets/digitaldatetime.js
+++ b/lib/ui/widgets/digitaldatetime.js
@@ -80,6 +80,9 @@ var dateFormats = [
 function DigitalDateTime(id, options, streamBundle, instrumentPanel) {
   BaseWidget.call(this, id, options, streamBundle, instrumentPanel);
   this.options.unit = "UTC";
+  if (typeof this.options.convertTo === 'undefined') {
+    this.options.convertTo = instrumentPanel.getPreferredUnit(this.options.unit);
+  }
   var valueStream = this.streamBundle.getStreamForSourcePath(this.options.sourceId, this.options.path);
   const conversion = getConversion(this.options.unit, this.options.convertTo);
   valueStream = valueStream.map(function(value) {
@@ -91,19 +94,27 @@ function DigitalDateTime(id, options, streamBundle, instrumentPanel) {
       return value;
     }
   }.bind(this));
-  if ((typeof this.options.formatDateIndex === 'undefined') ||
-       (this.options.formatDateIndex < 0) ||
-       (this.options.formatDateIndex > dateFormats.length -1)) {
+  if (typeof this.options.formatDateIndex === 'undefined') {
     this.options.formatDateIndex = 0;
   }
+  this.options.formatDateIndex = this.options.formatDateIndex % dateFormats.length;
+
   class ReactComponent extends React.Component {
     constructor(props) {
       super(props);
+      this.handleTimeoutLabel = null;
+      this.originalLabel = this.props.options.label || props.options.path;
+      this.originalLabel = this.originalLabel.replace('navigation.', '');
+      this.originalLabel = this.originalLabel.replace('environment.', '');
+      this.originalLabel = this.originalLabel.replace('electrical.', '');
+
       this.state = {
         epochDate: undefined,
-        formatDateIndex: this.props.options.formatDateIndex
+        formatDateIndex: this.props.options.formatDateIndex,
+        widgetLabel: this.originalLabel
       };
       this.changeDateFormat = this.changeDateFormat.bind(this);
+      this.displayUnit = (options.convertTo !== "") ? options.convertTo : options.unit;
     }
 
     componentDidMount() {
@@ -121,27 +132,41 @@ function DigitalDateTime(id, options, streamBundle, instrumentPanel) {
       if (this.unsubscribe) {
         this.unsubscribe();
       }
+      clearTimeout(this.handleTimeoutLabel);
     }
     
     changeDateFormat(event) {
       if ((event.nativeEvent.offsetX > 50) || (event.nativeEvent.offsetY > 50)) { return }
-      const newFormatDateIndex = this.state.formatDateIndex === dateFormats.length -1 ? 0 : this.state.formatDateIndex +1;
-      this.setState({ formatDateIndex: newFormatDateIndex});
-      this.props.options.formatDateIndex = newFormatDateIndex;
-      this.props.instrumentPanel.persist();
+      const firstClic = (this.handleTimeoutLabel === null) ? true : false;
+      clearTimeout(this.handleTimeoutLabel);
+      this.handleTimeoutLabel = setTimeout(() => {
+        this.setState({widgetLabel: this.originalLabel});
+        this.handleTimeoutLabel = null;
+      }, 5000);
+      var newFormatDateIndex = this.state.formatDateIndex;
+      if (!firstClic) {
+        newFormatDateIndex = (newFormatDateIndex + 1) % dateFormats.length;
+        this.props.options.formatDateIndex = newFormatDateIndex;
+        this.props.instrumentPanel.persist();
+      }
+      this.setState({
+        formatDateIndex: newFormatDateIndex,
+        widgetLabel: dateFormats[newFormatDateIndex](new Date()).label
+      });
     }
-    
+
     render() {
       var textDate = {};
-      if(typeof this.state.epochDate !== 'undefined') {
+      try {
+        if (!Number.isInteger(this.state.epochDate)) {throw "Date is not a number!";}
         const dateObject = new Date(this.state.epochDate);
         textDate = dateFormats[this.state.formatDateIndex](dateObject);
-      } else {
-        textDate = {date: '--/--/--', time: '--:--:--'};
-      }
+      } catch (ex) {
+          textDate = {date: '--/--/--', time: '--:--:--'};
+        }
       return (
         <svg key={id} onClick={this.changeDateFormat} height="100%" width="100%" viewBox="0 0 20 30" stroke="none">
-          <text x="10" y="3" textAnchor="middle" fontSize="4" dominantBaseline="middle">{textDate.label + " (" + (options.convertTo !== undefined ? options.convertTo : options.unit) + ")"}</text>
+          <text x="10" y="3" textAnchor="middle" fontSize="4" dominantBaseline="middle">{this.state.widgetLabel + " (" + this.displayUnit + ")"}</text>
           <text x="10" y="10" textAnchor="middle" fontSize={textDate.fontSizeDate} dominantBaseline="middle">{textDate.date}</text>
           <text x="10" y="23" textAnchor="middle" fontSize="17" dominantBaseline="middle">{textDate.time}</text>
         </svg>
@@ -159,6 +184,8 @@ function DigitalDateTime(id, options, streamBundle, instrumentPanel) {
     options: this.options,
     instrumentPanel: this.instrumentPanel
   });
+
+  this.updateUnitData(this, {setUnit: false, setStream: false});
 }
 
 util.inherits(DigitalDateTime, BaseWidget);
@@ -189,9 +216,22 @@ DigitalDateTime.prototype.getInitialDimensions = function() {
   return {h:2};
 }
 
+DigitalDateTime.prototype.updateStream = function(widget, valueStream) {
+// no valueStream update required for this widget
+  widget.instrumentPanel.pushGridChanges();
+}
 
 export default {
   constructor: DigitalDateTime,
   type: "digitaldatetime",
-  paths: ['navigation.datetime']
+  paths: [
+   'navigation.datetime',
+   'environment.tide.timeLow',
+   'environment.tide.timeHigh',
+   'electrical.batteries.*.dateInstalled',
+   'electrical.inverters.*.dateInstalled',
+   'electrical.chargers.*.dateInstalled',
+   'electrical.alternators.*.dateInstalled',
+   'electrical.alternators.*.dateInstalled'
+ ]
 }


### PR DESCRIPTION
paths displayed by the digitaldatetime widget :
- navigation.datetime
- environment.tide.timeLow
- environment.tide.timeHigh
- electrical.batteries.*.dateInstalled
- electrical.inverters.*.dateInstalled
- electrical.chargers.*.dateInstalled
- electrical.alternators.*.dateInstalled
- electrical.alternators.*.dateInstalled