### PR TITLE
fix: avoid widget goes to fullscreen in design mode

### DIFF
--- a/lib/ui/main.js
+++ b/lib/ui/main.js
@@ -267,7 +267,7 @@ class App extends React.Component {
   }
 
   toggleWidgetFullScreen(widget, event) {
-    if (typeof event !== 'undefined' && !widget.toolTips()) {
+    if (this.state.isLocked && typeof event !== 'undefined' && !widget.toolTips()) {
       var footer = document.getElementsByTagName('footer');
       var halfZoneSize = 50;
       var rect = event.currentTarget.getBoundingClientRect();


### PR DESCRIPTION
avoid widget goes to fullscreen in design mode
fix issue #163 