### PR TITLE
CORS problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ get it cleared by using a url with query parameter `?reset=true`.
 Newer browsers like Firefox suppress CORS (Cross Origin Resource Sharing) requests. No instruments will then be displayed in the browser. In the web server, CORS must be explicitly activated for the panel instrument. Details see here:
 
 https://developer.mozilla.org/en/docs/Web/HTTP/CORS
-
 https://enable-cors.org/server_apache.html
+https://alfilatov.com/posts/run-chrome-without-cors/
 
 For iOS user:
 =============

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Trouble?
 ========
 First consult the online help, link above or click on **?** icon inside the GUI.  
 InstrumentPanel stores some of the settings in the browser's localstorage. In case there is some garbage there you can
-get it cleared by using a url with query parameter `?reset=true`.  
+get it cleared by using a url with query parameter `?reset=true`.
+
+Newer browsers like Firefox suppress CORS (Cross Origin Resource Sharing) requests. No instruments will then be displayed in the browser. In the web server, CORS must be explicitly activated for the panel instrument. Details see here:
+https://developer.mozilla.org/de/docs/Web/HTTP/CORS 
 
 For iOS user:
 =============

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ get it cleared by using a url with query parameter `?reset=true`.
 Newer browsers like Firefox suppress CORS (Cross Origin Resource Sharing) requests. No instruments will then be displayed in the browser. In the web server, CORS must be explicitly activated for the panel instrument. Details see here:
 
 https://developer.mozilla.org/en/docs/Web/HTTP/CORS
+
 https://enable-cors.org/server_apache.html
+
 https://alfilatov.com/posts/run-chrome-without-cors/
 
 For iOS user:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ InstrumentPanel stores some of the settings in the browser's localstorage. In ca
 get it cleared by using a url with query parameter `?reset=true`.
 
 Newer browsers like Firefox suppress CORS (Cross Origin Resource Sharing) requests. No instruments will then be displayed in the browser. In the web server, CORS must be explicitly activated for the panel instrument. Details see here:
-https://developer.mozilla.org/en/docs/Web/HTTP/CORS 
+
+https://developer.mozilla.org/en/docs/Web/HTTP/CORS
+
+https://enable-cors.org/server_apache.html
 
 For iOS user:
 =============

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ InstrumentPanel stores some of the settings in the browser's localstorage. In ca
 get it cleared by using a url with query parameter `?reset=true`.
 
 Newer browsers like Firefox suppress CORS (Cross Origin Resource Sharing) requests. No instruments will then be displayed in the browser. In the web server, CORS must be explicitly activated for the panel instrument. Details see here:
-https://developer.mozilla.org/de/docs/Web/HTTP/CORS 
+https://developer.mozilla.org/en/docs/Web/HTTP/CORS 
 
 For iOS user:
 =============


### PR DESCRIPTION
Newer browsers like Firefox suppress CORS (Cross Origin Resource Sharing) requests. No instruments will then be displayed in the browser. In the web server, CORS must be explicitly activated for the panel instrument.