### PR TITLE
fix: migrate paths with "no_source" to real source

### DIFF
--- a/lib/streambundle.js
+++ b/lib/streambundle.js
@@ -60,7 +60,12 @@ StreamBundle.prototype.handleDelta = function(delta, instrumentPanel) {
     });
     update.values && update.values.forEach(function(pathValue) {
       if(pathValue.path) {
-        that.push(sourceId, pathValue);
+        if (sourceId === 'no_source'){
+          if (update.$source) that.push(update.$source, pathValue);
+          if (instrumentPanel.legacySourcesOn) that.push(sourceId, pathValue);
+        } else {
+          that.push(sourceId, pathValue);
+        }
         try {
           if ((pathValue.path === 'environment.mode') && instrumentPanel.isColorSchemeSetBySKPATH()) {
             const nightOn = pathValue.value.toString() === 'night';

--- a/lib/ui/instrumentpanel.js
+++ b/lib/ui/instrumentpanel.js
@@ -134,6 +134,7 @@ export default function InstrumentPanel(streamBundle) {
   this.widgetActiveMode = WA_BASE_DATA;
   this.signalkServer; // undefined if no signalkServer in URL
   this.loginStatus = {};
+  this.legacySourcesOn = false;
   var isUnkownKey = function(key) {
     return typeof this.getCurrentPage().knownKeys[key.key] === 'undefined';
   }.bind(this)
@@ -357,6 +358,7 @@ InstrumentPanel.prototype.serializableSettings = function() {
 
 InstrumentPanel.prototype.setWidgetData = function(widgetData) {
   var that = this;
+  this.legacySourcesOn = false;
   if (widgetData && widgetData.pages) {
     this.pages = widgetData.pages.map(function(page, pageID) {
       let cleanedWidgets = [];
@@ -365,6 +367,7 @@ InstrumentPanel.prototype.setWidgetData = function(widgetData) {
           if (!widget.id) widget.id = pageID + '-' + key;
           if (widget.options && widget.options.delete !== true) {
             widget.options.delete = undefined;
+            if (widget.options.sourceId === 'no_source') that.legacySourcesOn = true;
             cleanedWidgets.push(widget);
           } else {
             let layoutId = page.layout.findIndex((layout) => {return layout.i === widget.id});
@@ -417,16 +420,20 @@ InstrumentPanel.prototype.onWidgetChange = function(widget) {
   this.pushGridChanges();
 }
 
-InstrumentPanel.prototype.persist = function() {
+InstrumentPanel.prototype.persist = function(immediate) {
   if (this.currentPage !== notificationPageId) {
     var that = this;
     if (this.handleSaveLayoutDelay !== null) {
       clearTimeout(this.handleSaveLayoutDelay);
     }
-    this.handleSaveLayoutDelay = setTimeout(() => {
-      that.handleSaveLayoutDelay = null;
+    if (immediate) {
       storeGrid(this.SignalkClient.get('hostname'), this.layoutName, that.serializableSettings());
-    }, 1000);
+    } else {
+      this.handleSaveLayoutDelay = setTimeout(() => {
+        that.handleSaveLayoutDelay = null;
+        storeGrid(this.SignalkClient.get('hostname'), this.layoutName, that.serializableSettings());
+      }, 1000);
+    }
   }
 }
 

--- a/lib/ui/settings/settingspanel.js
+++ b/lib/ui/settings/settingspanel.js
@@ -8,6 +8,7 @@ import PreferredUnits from './preferredunits';
 import ResetSettings from './resetsettings';
 import ColorSchemeSettings from './colorschemesettings';
 import SaveLoadSettingsUnits from './saveload';
+import {reloadWithParams} from '../../util/browser';
 import {
   saveDisplayKey,
   loadDisplayKey
@@ -30,6 +31,8 @@ export default class SettingsPanel extends React.Component {
     }
     this.handleSelect = this.handleSelect.bind(this);
     this.getContentBySettingsKey = this.getContentBySettingsKey.bind(this);
+    this.isNoSourceInLayout = this.isNoSourceInLayout.bind(this);
+    this.deleteWidgetsNoSource = this.deleteWidgetsNoSource.bind(this);
   }
 
   render() {
@@ -41,6 +44,7 @@ export default class SettingsPanel extends React.Component {
     return (
       <React.Fragment>
         {(this.props.instrumentPanel.isReloadRequired())? reloadMessage : undefined}
+        {this.isNoSourceInLayout()}
         <Panel>
           <Panel.Heading>
             <div className="pull-left">
@@ -82,6 +86,45 @@ export default class SettingsPanel extends React.Component {
     this.setState({
       activeKey: selectedKey
     });
+  }
+
+  isNoSourceInLayout() {
+    if (this.props.instrumentPanel.legacySourcesOn) {
+      let pageKeys = [];
+      let activeWidget = false
+      let pageText = '';
+      let messageActive = '';
+      let pageIter = this.props.instrumentPanel.pages.keys();
+      for (const pageKey of pageIter) {
+        this.props.instrumentPanel.getWidgets(pageKey).filter(widget => widget.options.sourceId === 'no_source' && widget.options.active).forEach(widget => {
+          if (pageKeys.indexOf(pageKey) === -1) pageKeys.push(pageKey);
+          activeWidget = true;
+        })
+      }
+      pageText = pageKeys.reduce((acc, val) => acc + ((acc !== '')?',':'') + (val +1), '');
+      console.log(activeWidget, pageText);
+      if (pageText !== '') {
+        messageActive = "uncheck 'Show on grid' on all widgets with a red dotted border in page "+ pageText + ", select the appropriate new widget, check your new layout and then ";
+      }
+      return (
+        <Alert bsStyle="warning">
+          You use paths with 'no_source' as reference in your layout. Please, {messageActive} clic on&nbsp;
+          <Button className='headerEdit' bsSize='xsmall' disabled={activeWidget} onClick={this.deleteWidgetsNoSource}>Delete outdated widgets</Button>
+        </Alert>
+      );
+    }
+  }
+
+  deleteWidgetsNoSource() {
+    let pageIter = this.props.instrumentPanel.pages.keys();
+    for (const pageKey of pageIter) {
+      this.props.instrumentPanel.getWidgets(pageKey).filter(widget => widget.options.sourceId === 'no_source').forEach(widget => {
+        widget.setActive(false);
+        widget.setDelete(true);
+      })
+    }
+    this.props.instrumentPanel.persist(true);
+    reloadWithParams(this.props.instrumentPanel.getReloadParams());
   }
 };
 

--- a/lib/ui/settings/widgetcell.js
+++ b/lib/ui/settings/widgetcell.js
@@ -27,10 +27,19 @@ export default class WidgetCell extends React.Component {
     this.renderLight = this.renderLight.bind(this);
     this.pushCellChange = this.pushCellChange.bind(this);
     this.checkBoxActiveDelete = this.checkBoxActiveDelete.bind(this);
+    this.getBorderClass = this.getBorderClass.bind(this);
     this.state = {
       showAllPaths: false,
       cellChange: false
     }
+  }
+
+  getBorderClass() {
+    return (
+      this.props.widget.options.sourceId === 'no_source' &&
+      this.props.widget.options.active === true &&
+      this.props.widget.instrumentPanel.currentPage !== notificationPageId
+    ) ? 'item itemOutdated' : 'item';
   }
 
   pushCellChange() {
@@ -74,6 +83,7 @@ export default class WidgetCell extends React.Component {
       </React.Fragment>
     )
   }
+
   render() {
     return (this.props.editMode) ? this.renderFull() : this.renderLight();
   }
@@ -93,7 +103,7 @@ export default class WidgetCell extends React.Component {
       });
 
     return (
-      <div className='item'>
+      <div className={this.getBorderClass()}>
         <div className='header'>
           {this.checkBoxActiveDelete()}
           <Button className='headerEdit' bsSize="xsmall" onClick={() => this.props.changeWidgetInEdit('')}>Done</Button>
@@ -115,7 +125,7 @@ export default class WidgetCell extends React.Component {
 
   renderLight() {
     return (
-      <div className='item'>
+      <div className={this.getBorderClass()}>
         <div className='header'>
           {this.checkBoxActiveDelete()}
           <Button className='headerEdit' bsSize="xsmall" onClick={() => this.props.changeWidgetInEdit(this.props.widget.id)}>Edit</Button>

--- a/public/css/instrumentpanel.css
+++ b/public/css/instrumentpanel.css
@@ -224,6 +224,12 @@ div.widget svg {
  margin-top: 4px;
 }
 
+.itemOutdated {
+ border-color: var(--border-item-outdated);
+ border-style: dashed;
+ border-width: 2px;
+}
+
 .items .item .header {
  display: flex;
  height: 22px;
@@ -494,6 +500,7 @@ input[type="file"] {
   --text-color: tomato;
   --text-settings-color: #535378;
   --border-color: #8a8a8a;
+  --border-item-outdated: red;
  }
 }
 
@@ -509,5 +516,6 @@ input[type="file"] {
   --text-color: #000;
   --text-settings-color: #3c4b8c;
   --border-color: silver;
+  --border-item-outdated: red;
  }
 }


### PR DESCRIPTION
uncheck `Show on grid` on all widgets with a red dotted border in all pages
![image](https://user-images.githubusercontent.com/31212553/115109225-c1b7c100-9f74-11eb-8b9a-758a07eecc26.png)
and replace them by checking the `Show on grid` box on the widget with the right source
![image](https://user-images.githubusercontent.com/31212553/115109307-57535080-9f75-11eb-856f-f0e7461bb8f4.png)
