### PR TITLE
fix: loss of units when preferred units are not set

### DIFF
--- a/lib/streambundle.js
+++ b/lib/streambundle.js
@@ -19,6 +19,8 @@ Key is a 'standard' single string representation  of source id
 and path produced with signalkSchema.keyForSourceIdPath.
 
 */
+import Debug from 'debug';
+const debug = Debug('instrumentpanel:streambundle')
 import {Bus} from 'baconjs';
 
 function getSourceId(source) {
@@ -56,6 +58,7 @@ StreamBundle.prototype.handleDelta = function(delta, instrumentPanel) {
     var sourceId = getSourceId(update.source);
     update.meta && update.meta.forEach(function(pathMeta) {
       pathMeta = instrumentPanel.schemadata.mergeMetaInCache(pathMeta);
+      debug("[handleDelta] receive new meta:" + JSON.stringify(pathMeta))
       that.metasStream.push(pathMeta);
     });
     update.values && update.values.forEach(function(pathValue) {

--- a/lib/ui/instrumentpanel.js
+++ b/lib/ui/instrumentpanel.js
@@ -2,13 +2,14 @@ import BaconModel from 'bacon.model';
 import compareVersions from 'compare-versions';
 import Debug from 'debug';
 
-const debug = Debug('instrumentpanel')
+const debug = Debug('instrumentpanel:instrumentpanel')
 
 import {
   getUrlParameter,
   getLayoutName
 } from '../util/browser';
 import {
+  isPreferredUnits,
   retrievePreferredUnits,
   storePreferredUnits,
   storeGrid,
@@ -16,6 +17,9 @@ import {
   retrieveWidgetActiveMode,
   storeWidgetActiveMode
 } from '../util/localstorage';
+import {
+  retrievePreferredUnits as ssRetrievePreferredUnits
+} from '../util/serverstorage';
 import SignalKSchemaData from '../util/signalkschemadata';
 import {
   getConversionsList,
@@ -135,6 +139,9 @@ export default function InstrumentPanel(streamBundle) {
   this.signalkServer; // undefined if no signalkServer in URL
   this.loginStatus = {};
   this.legacySourcesOn = false;
+  this.connectionInfo = null;
+  this.applicationData = false;
+  this.metaUpdateInWS =false;
   var isUnkownKey = function(key) {
     return typeof this.getCurrentPage().knownKeys[key.key] === 'undefined';
   }.bind(this)
@@ -293,6 +300,34 @@ InstrumentPanel.prototype.pushGridChanges = function() {
 }
 
 InstrumentPanel.prototype.dispatch = function(delta) {
+  if (this.connectionInfo === null) {
+    if (delta && typeof delta === 'object' && delta.hasOwnProperty('name') && delta.hasOwnProperty('version') && delta.hasOwnProperty('roles')) {
+      debug("[dispatch] connectionInfo received: " + JSON.stringify(delta));
+      this.connectionInfo = delta;
+      if (this.connectionInfo && this.connectionInfo.name === 'signalk-server') {
+        this.applicationData = (this.connectionInfo && this.connectionInfo.name === 'signalk-server' && compareVersions(this.connectionInfo.version, '1.27.0') >= 0) || false;
+        this.metaUpdateInWS = (this.connectionInfo && this.connectionInfo.name === 'signalk-server' && compareVersions(this.connectionInfo.version, '1.37.5') >= 0) || false;
+      }
+      debug("[dispatch] storage server available: " + this.applicationData);
+      debug("[dispatch] meta update in WS: " + this.metaUpdateInWS);
+      if (!isPreferredUnits() && this.applicationData) {
+        debug("[dispatch] applicationData is available on server & no local preferred units");
+        ssRetrievePreferredUnits(
+          this.SignalkClient,
+          false, // only from global
+          (preferredUnits => {
+            debug("[dispatch] ssRetrievePreferredUnits return: " + JSON.stringify(preferredUnits));
+            if (preferredUnits === null) { preferredUnits = {} }
+            storePreferredUnits(preferredUnits);
+            this.loadPreferredUnits();
+          })
+        )
+      }
+      // IP connected to a WS, connectionInfo received,now loading grid layout if available
+      this.loadGrid();
+      return;
+    }
+  }
   this.streamBundle.handleDelta(delta, this);
 }
 
@@ -315,6 +350,7 @@ InstrumentPanel.prototype.handlePossiblyNewSource = function(newSource) {
       path: newSource.path,
       active: this.getWidgetActiveModeByPath(newSource.path) || notification
     }, this.streamBundle, this);
+    debug("[handlePossiblyNewSource] create new widget type:" + module.type + " for path:" + newSource.path + " / source:" + newSource.sourceId);
     widget.handleNewSource.call(widget, newSource);
     this.getWidgets(handlePage).push(widget);
     if ((this.currentPage === handlePage) && (widget.options.active)) {
@@ -481,7 +517,7 @@ InstrumentPanel.prototype.getDisabledWidgets = function(page) {
   return result;
 }
 
-InstrumentPanel.prototype.connected = function() {
+InstrumentPanel.prototype.loadGrid = function() {
   this.schemadata = new SignalKSchemaData({
     host: this.SignalkClient.get('hostname'),
     port: this.SignalkClient.get('port'),
@@ -595,34 +631,34 @@ InstrumentPanel.prototype.getColumnforPath = function(path) {
 
 InstrumentPanel.prototype.loadPreferredUnits = function() {
   var savedPreferredUnitsList = retrievePreferredUnits();
-  if (savedPreferredUnitsList === null) {return;}
-
-  if (savedPreferredUnitsList['date']) {
-    if (getIndexFromDateFormatLabel(savedPreferredUnitsList['date']) > 0 ) {
-      this.preferredUnits['date'] = savedPreferredUnitsList['date'];
+  if (savedPreferredUnitsList !== null) {
+    if (savedPreferredUnitsList['date']) {
+      if (getIndexFromDateFormatLabel(savedPreferredUnitsList['date']) > 0 ) {
+        this.preferredUnits['date'] = savedPreferredUnitsList['date'];
+      }
+      savedPreferredUnitsList['date'] = undefined;
     }
-    savedPreferredUnitsList['date'] = undefined;
+
+    if (savedPreferredUnitsList['position']) {
+      if (getIndexFromPositionFormatLabel(savedPreferredUnitsList['position']) > 0 ) {
+        this.preferredUnits['position'] = savedPreferredUnitsList['position'];
+      }
+      savedPreferredUnitsList['position'] = undefined;
+    }
+
+    getConversionsList().map( srcUnit => {
+      const dstUnit = savedPreferredUnitsList[srcUnit];
+      if ((typeof dstUnit !== 'undefined') && (typeof getConversion(srcUnit, dstUnit) === 'function')) {
+        this.preferredUnits[srcUnit] = dstUnit;
+      }
+    })
+    debug("[instrumentpanel] preferred units loaded: " + JSON.stringify(this.preferredUnits))
+    this.savePreferredUnits();
   }
-
-  if (savedPreferredUnitsList['position']) {
-    if (getIndexFromPositionFormatLabel(savedPreferredUnitsList['position']) > 0 ) {
-      this.preferredUnits['position'] = savedPreferredUnitsList['position'];
-    }
-    savedPreferredUnitsList['position'] = undefined;
-  }
-
-  getConversionsList().map( srcUnit => {
-    const dstUnit = savedPreferredUnitsList[srcUnit];
-    if ((typeof dstUnit !== 'undefined') &&
-        (typeof getConversion(srcUnit, dstUnit) === 'function')) {
-      this.preferredUnits[srcUnit] = dstUnit;
-    }
-  })
-
-  this.savePreferredUnits();
 }
 
 InstrumentPanel.prototype.savePreferredUnits = function() {
+  debug("[instrumentpanel] save preferred units: " + JSON.stringify(this.preferredUnits));
   storePreferredUnits(this.preferredUnits);
 }
 
@@ -709,17 +745,6 @@ InstrumentPanel.prototype.getReloadParams = function() {
   let params = {layout: this.layoutName};
   if (typeof this.signalkServer !== 'undefined') params['signalkServer'] = this.signalkServer;
   return params;
-}
-
-InstrumentPanel.prototype.getSsAvailable = function() {
-  var connectionInfo = this.SignalkClient.connectionInfo;
-  debug("[getSsAvailable] connectionInfo: " + JSON.stringify(connectionInfo));
-  return (connectionInfo && connectionInfo.name === 'signalk-server' && compareVersions(connectionInfo.version, '1.27.0') >= 0);
-}
-
-InstrumentPanel.prototype.isMetaUpdateInWS = function() {
-  var connectionInfo = this.SignalkClient.connectionInfo;
-  return (connectionInfo && connectionInfo.name === 'signalk-server' && compareVersions(connectionInfo.version, '1.37.5') >= 0);
 }
 
 InstrumentPanel.prototype.retrieveLoginStatus = function(cb) {

--- a/lib/ui/navbar.js
+++ b/lib/ui/navbar.js
@@ -22,12 +22,7 @@ import {
   storeColorScheme,
   retrieveColorScheme,
   retrieveToken,
-  isPreferredUnits,
-  storePreferredUnits
 } from '../util/localstorage';
-import {
-  retrievePreferredUnits as ssRetrievePreferredUnits
-} from '../util/serverstorage';
 import {
   notificationPageId
 } from './settings/constants'
@@ -62,7 +57,6 @@ export default class IpNavBar extends React.Component {
     this.handleNavClick = this.handleNavClick.bind(this);
     this.handleFullscreenChange = this.handleFullscreenChange.bind(this);
     this.handleStandAloneMode = this.handleStandAloneMode.bind(this);
-    this.enableDispatchDeltas = this.enableDispatchDeltas.bind(this);
     this.toogleFullscreen = this.toogleFullscreen.bind(this);
     onSwipe({ node: document});
     this.standalone = false;
@@ -392,7 +386,6 @@ export default class IpNavBar extends React.Component {
     const SignalkClient = this.props.instrumentPanel.SignalkClient;
     if (!this.state.connected) {
       SignalkClient.cleanupListeners();
-      SignalkClient.connect();
       SignalkClient.on('connect', () => {
         // For debug only with npm start when IP running at 3001 listening port
         var token = retrieveToken();
@@ -402,28 +395,14 @@ export default class IpNavBar extends React.Component {
         }
         // End for debug only
         that.setState({retries: 0});
-        debug("[wsConnect] SignalkClient connected & Waiting for connectionInfo");
+        debug("[wsConnect] SignalkClient connected");
+        that.props.model.lens("connected").set(true); // allows grid display
+        that.setState({"connected": true}); // navbar display "connectedButtons"
+        debug("[wsConnect] subscribe to vessels.self");
+        that.props.instrumentPanel.SignalkClient.subscribe({context:'vessels.self',subscribe:[{ path:'*'}]});
+        that.showIpNavBar();
       });
-      SignalkClient.on('connectionInfo', (data => {
-        debug("[wsConnect] connectionInfo received");
-        if (!isPreferredUnits() && this.props.instrumentPanel.getSsAvailable()) {
-          debug("[wsConnect] applicationData is available on server & no local preferred units");
-          ssRetrievePreferredUnits(
-            SignalkClient,
-            false, // only from global
-            (preferredUnits => {
-              debug("[wsConnect] retrievePreferredUnits return:" + JSON.stringify(preferredUnits));
-              if (preferredUnits !== null) {
-                storePreferredUnits(preferredUnits);
-                this.props.instrumentPanel.loadPreferredUnits();
-              }
-              that.enableDispatchDeltas();
-            })
-          )
-        } else {
-            that.enableDispatchDeltas();
-          }
-      }));
+      SignalkClient.on('delta', that.props.instrumentPanel.dispatch.bind(that.props.instrumentPanel));
       SignalkClient.on('error', (err) => {
         debug("[wsConnect] error:" + JSON.stringify(err));
         that.setState({
@@ -445,17 +424,8 @@ export default class IpNavBar extends React.Component {
       SignalkClient.on('retries', (retries) => {
         that.setState({retries: retries});
       });
+      SignalkClient.connect();
     }
-  }
-
-  enableDispatchDeltas() {
-    this.props.model.lens("connected").set(true); // allows grid display
-    this.setState({"connected": true}); // navbar display "connectedButtons"
-    debug("[enableDispatchDeltas] subscribe to vessels.self & start dispatching deltas");
-    this.props.instrumentPanel.SignalkClient.subscribe({context:'vessels.self',subscribe:[{ path:'*'}]});
-    this.props.instrumentPanel.SignalkClient.on('delta', this.props.instrumentPanel.dispatch.bind(this.props.instrumentPanel));
-    this.props.instrumentPanel.connected();
-    this.showIpNavBar();
   }
 
   handleNavClick(event) {

--- a/lib/ui/settings/saveload.js
+++ b/lib/ui/settings/saveload.js
@@ -52,7 +52,6 @@ export default class SaveLoadSettingsUnits extends React.Component {
     this.getSsLayouts = this.getSsLayouts.bind(this);
     this.renderSsLayoutsLoad = this.renderSsLayoutsLoad.bind(this);
     this.skHostname = this.props.instrumentPanel.SignalkClient.get('hostname');
-    this.ssAvaliable = this.props.instrumentPanel.getSsAvailable();
     this.state =  {
       ssLayouts: {},
       ssLayoutLoadKey: '',
@@ -77,7 +76,7 @@ export default class SaveLoadSettingsUnits extends React.Component {
   }
 
   checkPreferredUnits() {
-    if (! this.ssAvaliable) {return null}
+    if (! this.props.instrumentPanel.applicationData) {return null}
     var that = this;
 
     ssIsPreferredUnits(
@@ -98,7 +97,7 @@ export default class SaveLoadSettingsUnits extends React.Component {
   }
 
   getSsLayouts() {
-    if (! this.ssAvaliable) {return null}
+    if (! this.props.instrumentPanel.applicationData) {return null}
     var that = this;
 
     function fillInfos(date, infos, isUser) {
@@ -356,8 +355,8 @@ export default class SaveLoadSettingsUnits extends React.Component {
     )
   }
 
-  renderSsLayoutsSave () {
-    if (!this.ssAvaliable || !(this.state.readWriteLevel || this.state.adminLevel)) {return null}
+  renderSsLayoutsSave() {
+    if (!this.props.instrumentPanel.applicationData || !(this.state.readWriteLevel || this.state.adminLevel)) {return null}
     return (
       <div>
         <Button
@@ -371,8 +370,8 @@ export default class SaveLoadSettingsUnits extends React.Component {
     )
   }
 
-  renderSsLayoutsLoad () {
-    if (! this.ssAvaliable) {return null}
+  renderSsLayoutsLoad() {
+    if (! this.props.instrumentPanel.applicationData) {return null}
     var infoDetails = null;
     var that = this;
     var deleteButton = (
@@ -440,8 +439,8 @@ export default class SaveLoadSettingsUnits extends React.Component {
     )
   }
 
-  renderSsPrefUnitsSave () {
-    if (!this.ssAvaliable || !(this.state.readWriteLevel || this.state.adminLevel)) {return null}
+  renderSsPrefUnitsSave() {
+    if (!this.props.instrumentPanel.applicationData || !(this.state.readWriteLevel || this.state.adminLevel)) {return null}
     return (
       <div>
         <Button
@@ -455,8 +454,8 @@ export default class SaveLoadSettingsUnits extends React.Component {
     )
   }
 
-  renderSsPrefUnitsLoad () {
-    if (! this.ssAvaliable) {return null}
+  renderSsPrefUnitsLoad() {
+    if (!this.props.instrumentPanel.applicationData) {return null}
     var disableBtn = (
       this.state.readOnlyButton ||
       (this.state.ssUser && !this.state.isUserPreferredUnits) ||
@@ -480,7 +479,7 @@ export default class SaveLoadSettingsUnits extends React.Component {
 
   renderIsLoggedAndSsAvaliable() {
     const loginUrl = window.location.origin + '/admin/#/login';
-    if (!this.ssAvaliable) {
+    if (!this.props.instrumentPanel.applicationData) {
       return (
         <Alert bsStyle="info">
           <b>Save and Load</b> on the server is only available on the Signal K server version &gt; <b>1.27.0</b>
@@ -519,7 +518,7 @@ export default class SaveLoadSettingsUnits extends React.Component {
   }
 
   renderUserOrGlobalChoice(actionTxt, forWrite=false) {
-    if (!this.ssAvaliable) {return null}
+    if (!this.props.instrumentPanel.applicationData) {return null}
     if (!this.state.adminLevel && forWrite) {return null}
     return (
       <React.Fragment>
@@ -554,7 +553,7 @@ export default class SaveLoadSettingsUnits extends React.Component {
             {this.renderUserOrGlobalChoice('save for', true)}
             {this.renderSsLayoutsSave()}
             {this.renderSsPrefUnitsSave()}
-            {this.renderIsLoggedAndSsAvaliable()}
+            {this.renderIsLoggedAndprops.instrumentPanel.applicationData()}
           </Well >
           {this.renderFileSave()}
         </div>

--- a/lib/ui/widgets/basewidget.js
+++ b/lib/ui/widgets/basewidget.js
@@ -1,3 +1,7 @@
+/*
+import Debug from 'debug';
+const debug = Debug('instrumentpanel:basewidget')
+*/
 import React from 'react';
 import {Bus} from 'baconjs';
 
@@ -31,7 +35,7 @@ export default function BaseWidget(id, options, streamBundle, instrumentPanel) {
   }).onValue( (pathMeta) => {
     this.optionsBundle.setOptions(this.metaToOptions(pathMeta))
   })
-  instrumentPanel.schemadata.getMetaForVesselPath(this.options.path, instrumentPanel.isMetaUpdateInWS())
+  instrumentPanel.schemadata.getMetaForVesselPath(this.options.path, instrumentPanel.metaUpdateInWS)
     .then(meta => {
       this.streamBundle.metasStream.push({path: this.options.path, value: meta});
   })

--- a/lib/util/signalk-client.js
+++ b/lib/util/signalk-client.js
@@ -57,7 +57,7 @@ export default class SkClient extends EventEmitter {
   get (key) {
     return this.options[key] || null
   }
-
+/* now done in instrumentpanel.js
   set connectionInfo (data) {
     debug(`[set connectionInfo] data=${JSON.stringify(data)}`)
     this._connection = data
@@ -69,6 +69,7 @@ export default class SkClient extends EventEmitter {
   get connectionInfo () {
     return this._connection
   }
+*/
 
   buildURI (protocol) {
     let uri = this.options.useTLS === true ? `${protocol}s://` : `${protocol}://`
@@ -108,7 +109,9 @@ export default class SkClient extends EventEmitter {
   }
 
   reconnect () {
+/* now done in instrumentpanel.js
     this.connectionInfo = null;
+*/
     if (this.isConnecting === true) {
       return
     }
@@ -231,12 +234,13 @@ export default class SkClient extends EventEmitter {
     } catch (e) {
       console.log(`[Connection: ${this.options.hostname}] Error parsing data: ${e.message}`)
     }
-
+/* now done in instrumentpanel.js
     if (this.connectionInfo === null) {
       if (data && typeof data === 'object' && data.hasOwnProperty('name') && data.hasOwnProperty('version') && data.hasOwnProperty('roles')) {
         this.connectionInfo = data
       }
     }
+*/
     this.emit('delta', data)
   }
 


### PR DESCRIPTION
- Correcting for loss of units when preferred units are not fixed
- Avoid the loss of the first meta updates and delta updates at the beginning of the connection
- Improvement of the processing of the connection information
- Creation of preferred units when the server does not provide any
- Added more relevant debugging