### PR TITLE
fix: better detection of dead websocket

### DIFF
--- a/lib/ui/instrumentpanel.js
+++ b/lib/ui/instrumentpanel.js
@@ -175,7 +175,8 @@ export default function InstrumentPanel(streamBundle) {
     reconnect: true,
     autoConnect: false,
     notifications: false,
-    maxRetries: -1
+    maxRetries: -1,
+    wsKeepaliveInterval: 10
   });
 }
 

--- a/lib/util/signalk-client.js
+++ b/lib/util/signalk-client.js
@@ -22,6 +22,7 @@ export default class SkClient extends EventEmitter {
       maxRetries: 100,
       username: null,
       password: null,
+      wsKeepaliveInterval: 0,
       ...options
     }
     this.httpURI = this.buildURI('http')
@@ -31,6 +32,7 @@ export default class SkClient extends EventEmitter {
     this.socket = null
     this.lastMessage = -1
     this.isConnecting = false
+    this.wsKeepaliveIntervalMs = this.options.wsKeepaliveInterval * 1000
     
     this._fetchReady = false
     this._bearerTokenPrefix = this.options.bearerTokenPrefix || 'Bearer'
@@ -38,6 +40,7 @@ export default class SkClient extends EventEmitter {
     this._retries = 0
     this._connection = null
 
+    this.keepalivedAndReschedule = this.keepalivedAndReschedule.bind(this)
     this.onWSMessage = this._onWSMessage.bind(this)
     this.onWSOpen = this._onWSOpen.bind(this)
     this.onWSClose = this._onWSClose.bind(this)
@@ -244,12 +247,22 @@ export default class SkClient extends EventEmitter {
     this.emit('delta', data)
   }
 
+  keepalivedAndReschedule() {
+    if (this.connected === true) {
+      if (this.lastMessage < Date.now() - this.wsKeepaliveIntervalMs) {
+        this.socket.send("{}");
+      }
+      setTimeout(this.keepalivedAndReschedule, this.wsKeepaliveIntervalMs);
+    }
+  }
+
   _onWSOpen () {
     debug('[_onWSOpen] called with wsURI:', this.wsURI)
     this._connection = null
     this.connected = true
     this.isConnecting = false
     this._retries = 0
+    if(this.options.wsKeepaliveInterval > 0) this.keepalivedAndReschedule()
     this.emit('connect')
   }
 


### PR DESCRIPTION
Sends an empty message to the websocket every 10 seconds when the client does not receive any more update from the server to detect if the socket is dead.