### PR TITLE
fix: temperature and date display formats

### DIFF
--- a/lib/ui/settings/conversions.js
+++ b/lib/ui/settings/conversions.js
@@ -145,6 +145,16 @@ var conversions = {
   }
 }
 
+var unitCorrections = {
+  "C": "°C",
+  "F": "°F",
+}
+
+// if the unit is in the corrections list, return the corrected unit, otherwise return the unit
+export function getCorrectedUnit(unit) {
+  return unitCorrections[unit] || unit;
+}
+
 export function conversionsToOptions(unit) {
   const conversionsForUnit = conversions[unit];
   if (conversionsForUnit) {

--- a/lib/ui/settings/conversions.js
+++ b/lib/ui/settings/conversions.js
@@ -38,8 +38,8 @@ var conversions = {
     "g/h": Qty.swiftConverter("m^3/s", "gallon/hour")
   },
   "K": {
-    "C": Qty.swiftConverter("tempK", "tempC"),
-    "F": Qty.swiftConverter("tempK", "tempF")
+    "°C": Qty.swiftConverter("tempK", "tempC"),
+    "°F": Qty.swiftConverter("tempK", "tempF")
   },
   "Hz": {
     "1/min": function(hz) {

--- a/lib/ui/widgets/basewidget.js
+++ b/lib/ui/widgets/basewidget.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Bus } from 'baconjs';
 import { Checkbox } from 'react-bootstrap';
-import { unitChoice, getConversion } from '../settings/conversions'
+import { unitChoice, getConversion, getCorrectedUnit } from '../settings/conversions'
 
 export default function BaseWidget(id, options, streamBundle, instrumentPanel) {
   this.id = id;
@@ -22,7 +22,9 @@ export default function BaseWidget(id, options, streamBundle, instrumentPanel) {
       return [options, value]
     }).toProperty(),
     getConversionForOptions: this.getConversionForOptions.bind(this),
-    getFinalUnit: (options) => { return (options.convertTo !== "") ? options.convertTo : options.unit; },
+    getFinalUnit: (options) => { 
+      return (options.convertTo !== "") ? options.convertTo = getCorrectedUnit(options.convertTo) : options.unit; 
+    },
     validateOptions: this.validateOptions
   }
 

--- a/lib/ui/widgets/basewidget.js
+++ b/lib/ui/widgets/basewidget.js
@@ -210,6 +210,7 @@ BaseWidget.prototype.getConversionForOptions = function () {
       return conversion;
     } else {
       console.error("No such conversion for " + this.options.unit + " to " + this.options.convertTo);
+      this.options.convertTo = '';
     }
   }
   return null;

--- a/lib/ui/widgets/digitaldatetime.js
+++ b/lib/ui/widgets/digitaldatetime.js
@@ -9,6 +9,16 @@ function pad(n) { return n < 10 ? '0' + n : n; }
 var defaultTextDate = { date: '--/--/--', time: '--:--:--', fontSizeDate: 9 };
 
 var dateFormats = [
+  // ISO 8601 style
+  function (dateObject) {
+    return {
+      date: dateObject.getUTCFullYear() + "-" + pad(dateObject.getUTCMonth() + 1) + "-" + pad(dateObject.getUTCDate()),
+      time: pad(dateObject.getUTCHours()) + ":" + pad(dateObject.getUTCMinutes()) + ":" + pad(dateObject.getUTCSeconds()),
+      label: 'YYYY-MM-DD',
+      fontSizeDate: 11
+    }
+  },
+  // YMD with slashes
   function (dateObject) {
     return {
       date: dateObject.getUTCFullYear() + "/" + pad(dateObject.getUTCMonth() + 1) + "/" + pad(dateObject.getUTCDate()),
@@ -17,6 +27,16 @@ var dateFormats = [
       fontSizeDate: 11
     }
   },
+  // DMY with dots
+  function (dateObject) {
+    return {
+      date: pad(dateObject.getUTCDate()) + "." + pad(dateObject.getUTCMonth() + 1) + "." + dateObject.getUTCFullYear(),
+      time: pad(dateObject.getUTCHours()) + ":" + pad(dateObject.getUTCMinutes()) + ":" + pad(dateObject.getUTCSeconds()),
+      label: 'DD.MM.YYYY',
+      fontSizeDate: 11
+    }
+  },
+  // DMY with slashes
   function (dateObject) {
     return {
       date: pad(dateObject.getUTCDate()) + "/" + pad(dateObject.getUTCMonth() + 1) + "/" + dateObject.getUTCFullYear(),
@@ -25,6 +45,7 @@ var dateFormats = [
       fontSizeDate: 11
     }
   },
+  // Philippines, Singapore, USA
   function (dateObject) {
     return {
       date: pad(pad(dateObject.getUTCMonth() + 1) + "/" + dateObject.getUTCDate()) + "/" + dateObject.getUTCFullYear(),
@@ -33,30 +54,7 @@ var dateFormats = [
       fontSizeDate: 11
     }
   },
-  function (dateObject) {
-    return {
-      date: dateObject.getUTCFullYear().toString().substring(2) + "/" + pad(dateObject.getUTCMonth() + 1) + "/" + pad(dateObject.getUTCDate()),
-      time: pad(dateObject.getUTCHours()) + ":" + pad(dateObject.getUTCMinutes()) + ":" + pad(dateObject.getUTCSeconds()),
-      label: 'YY/MM/DD',
-      fontSizeDate: 11
-    }
-  },
-  function (dateObject) {
-    return {
-      date: pad(dateObject.getUTCDate()) + "/" + pad(dateObject.getUTCMonth() + 1) + "/" + dateObject.getUTCFullYear().toString().substring(2),
-      time: pad(dateObject.getUTCHours()) + ":" + pad(dateObject.getUTCMinutes()) + ":" + pad(dateObject.getUTCSeconds()),
-      label: 'DD/MM/YY',
-      fontSizeDate: 11
-    }
-  },
-  function (dateObject) {
-    return {
-      date: pad(dateObject.getUTCMonth() + 1) + "/" + pad(dateObject.getUTCDate()) + "/" + dateObject.getUTCFullYear().toString().substring(2),
-      time: pad(dateObject.getUTCHours()) + ":" + pad(dateObject.getUTCMinutes()) + ":" + pad(dateObject.getUTCSeconds()),
-      label: 'MM/DD/YY',
-      fontSizeDate: 11
-    }
-  },
+  // Short-format date string in English
   function (dateObject) {
     return {
       date: dateObject.toDateString(),

--- a/lib/ui/widgets/digitaldatetime.js
+++ b/lib/ui/widgets/digitaldatetime.js
@@ -45,6 +45,15 @@ var dateFormats = [
       fontSizeDate: 11
     }
   },
+  // DMY with slashes and two-digit year
+  function (dateObject) {
+    return {
+      date: pad(dateObject.getUTCDate()) + "/" + pad(dateObject.getUTCMonth() + 1) + "/" + dateObject.getUTCFullYear().toString().substring(2),
+      time: pad(dateObject.getUTCHours()) + ":" + pad(dateObject.getUTCMinutes()) + ":" + pad(dateObject.getUTCSeconds()),
+      label: 'DD/MM/YYYY',
+      fontSizeDate: 11
+    }
+  },
   // Philippines, Singapore, USA
   function (dateObject) {
     return {


### PR DESCRIPTION
Celsius and Fahrenheit units were missing the degree mark (°). This has been fixed.

The selection of allowed date formats was IMO arbitrary and limited. It has been fixed to be more internationally representative (although still arbitrary - I tried to cover all common cases I found, though). This was slightly opinionated - I also dropped the two-digit-year variants because I don't think those are the official format in any locale.
