### PR TITLE
fix: /loginStatus is deprecated

### DIFF
--- a/lib/ui/instrumentpanel.js
+++ b/lib/ui/instrumentpanel.js
@@ -783,7 +783,7 @@ InstrumentPanel.prototype.retrieveLoginStatus = function (cb) {
       'Content-Type': 'application/json'
     }
   }
-  this.SignalkClient.fetch('/loginStatus', opts)
+  this.SignalkClient.fetch('/skServer/loginStatus', opts)
     .then(loginStatus => {
       debug("[fetch loginStatus] response OK:" + JSON.stringify(loginStatus))
       this.loginStatus = loginStatus;

--- a/lib/util/signalk-client.js
+++ b/lib/util/signalk-client.js
@@ -8,7 +8,7 @@ import Debug from 'debug'
 const debug = Debug('instrumentpanel:signalk-client')
 
 export default class SkClient extends EventEmitter {
-  constructor (options = {}) {
+  constructor(options = {}) {
     super()
     this.options = {
       hostname: 'localhost',
@@ -33,7 +33,7 @@ export default class SkClient extends EventEmitter {
     this.lastMessage = -1
     this.isConnecting = false
     this.wsKeepaliveIntervalMs = this.options.wsKeepaliveInterval * 1000
-    
+
     this._fetchReady = false
     this._bearerTokenPrefix = this.options.bearerTokenPrefix || 'Bearer'
     this._authenticated = false
@@ -52,29 +52,29 @@ export default class SkClient extends EventEmitter {
     }
   }
 
-  set (key, value) {
+  set(key, value) {
     this.options[key] = value
     return this
   }
 
-  get (key) {
+  get(key) {
     return this.options[key] || null
   }
-/* now done in instrumentpanel.js
-  set connectionInfo (data) {
-    debug(`[set connectionInfo] data=${JSON.stringify(data)}`)
-    this._connection = data
-    if (data !== null) {
-      this.emit('connectionInfo', data)
+  /* now done in instrumentpanel.js
+    set connectionInfo (data) {
+      debug(`[set connectionInfo] data=${JSON.stringify(data)}`)
+      this._connection = data
+      if (data !== null) {
+        this.emit('connectionInfo', data)
+      }
     }
-  }
+  
+    get connectionInfo () {
+      return this._connection
+    }
+  */
 
-  get connectionInfo () {
-    return this._connection
-  }
-*/
-
-  buildURI (protocol) {
+  buildURI(protocol) {
     let uri = this.options.useTLS === true ? `${protocol}s://` : `${protocol}://`
     uri += this.options.hostname
     uri += this.options.port === 80 ? '' : `:${this.options.port}`
@@ -93,7 +93,7 @@ export default class SkClient extends EventEmitter {
     return uri
   }
 
-  state () {
+  state() {
     return {
       connecting: this.isConnecting,
       connected: this.connected,
@@ -101,20 +101,20 @@ export default class SkClient extends EventEmitter {
     }
   }
 
-  disconnect () {
+  disconnect() {
     debug('[disconnect] called')
     this.shouldDisconnect = true
     this.reconnect()
   }
 
-  connect () {
+  connect() {
     this.reconnect()
   }
 
-  reconnect () {
-/* now done in instrumentpanel.js
-    this.connectionInfo = null;
-*/
+  reconnect() {
+    /* now done in instrumentpanel.js
+        this.connectionInfo = null;
+    */
     if (this.isConnecting === true) {
       return
     }
@@ -177,7 +177,7 @@ export default class SkClient extends EventEmitter {
         }
 
         debug(`[reconnect] successful auth request: ${JSON.stringify(result, null, 2)}`)
-     
+
         this._authenticated = true
         this._token = {
           kind: (typeof result.type === 'string' && result.type.trim() !== '') ? result.type : this._bearerTokenPrefix,
@@ -197,7 +197,7 @@ export default class SkClient extends EventEmitter {
       })
   }
 
-  setAuthenticated (token, kind = 'JWT') { // @FIXME default type should be Bearer
+  setAuthenticated(token, kind = 'JWT') { // @FIXME default type should be Bearer
     this.emit('fetchReady')
     this._authenticated = true
     this._token = {
@@ -206,7 +206,7 @@ export default class SkClient extends EventEmitter {
     }
   }
 
-  initiateSocket () {
+  initiateSocket() {
     debug(`[initiateSocket] retry counter: ${this._retries}/${this.options.maxRetries}`)
     this.socket = new WebSocket(this.wsURI)
     this.socket.addEventListener('message', this.onWSMessage)
@@ -215,7 +215,7 @@ export default class SkClient extends EventEmitter {
     this.socket.addEventListener('close', this.onWSClose)
   }
 
-  cleanupListeners () {
+  cleanupListeners() {
     debug(`[cleanupListeners] resetting auth and removing listeners`)
     // Reset authentication
     this._authenticated = false
@@ -226,7 +226,7 @@ export default class SkClient extends EventEmitter {
     this.removeAllListeners()
   }
 
-  _onWSMessage (evt) {
+  _onWSMessage(evt) {
     this.lastMessage = Date.now()
     let data = evt.data
 
@@ -237,13 +237,13 @@ export default class SkClient extends EventEmitter {
     } catch (e) {
       console.log(`[Connection: ${this.options.hostname}] Error parsing data: ${e.message}`)
     }
-/* now done in instrumentpanel.js
-    if (this.connectionInfo === null) {
-      if (data && typeof data === 'object' && data.hasOwnProperty('name') && data.hasOwnProperty('version') && data.hasOwnProperty('roles')) {
-        this.connectionInfo = data
-      }
-    }
-*/
+    /* now done in instrumentpanel.js
+        if (this.connectionInfo === null) {
+          if (data && typeof data === 'object' && data.hasOwnProperty('name') && data.hasOwnProperty('version') && data.hasOwnProperty('roles')) {
+            this.connectionInfo = data
+          }
+        }
+    */
     this.emit('delta', data)
   }
 
@@ -256,17 +256,17 @@ export default class SkClient extends EventEmitter {
     }
   }
 
-  _onWSOpen () {
+  _onWSOpen() {
     debug('[_onWSOpen] called with wsURI:', this.wsURI)
     this._connection = null
     this.connected = true
     this.isConnecting = false
     this._retries = 0
-    if(this.options.wsKeepaliveInterval > 0) this.keepalivedAndReschedule()
+    if (this.options.wsKeepaliveInterval > 0) this.keepalivedAndReschedule()
     this.emit('connect')
   }
 
-  _onWSError (err) {
+  _onWSError(err) {
     debug('[_onWSError] WS error', err.message || '')
     this._connection = null
     this._retries += 1
@@ -274,7 +274,7 @@ export default class SkClient extends EventEmitter {
     this.reconnect()
   }
 
-  _onWSClose (evt) {
+  _onWSClose(evt) {
     debug('[_onWSClose] called with wsURI:', this.wsURI)
     this.socket.removeEventListener('message', this.onWSMessage)
     this.socket.removeEventListener('open', this.onWSOpen)
@@ -290,11 +290,11 @@ export default class SkClient extends EventEmitter {
     this.reconnect()
   }
 
-  subscribe (subscribeCmd) {
+  subscribe(subscribeCmd) {
     return this.send(subscribeCmd)
   }
 
-  send (data) {
+  send(data) {
     if (this.connected !== true || this.socket === null) {
       return Promise.reject(new Error('Not connected to WebSocket'))
     }
@@ -330,7 +330,7 @@ export default class SkClient extends EventEmitter {
     return Promise.resolve(result)
   }
 
-  fetch (path, opts) {
+  fetch(path, opts) {
     if (path.charAt(0) !== '/') {
       path = `/${path}`
     }
@@ -381,8 +381,8 @@ export default class SkClient extends EventEmitter {
       URI = URI.replace('/signalk/v1/api/applicationData', '/signalk/v1/applicationData')
     }
 
-    if (URI.includes('/signalk/v1/api/loginStatus')) {
-      URI = URI.replace('/signalk/v1/api/loginStatus', '/loginStatus')
+    if (URI.includes('/signalk/v1/api/skServer/loginStatus')) {
+      URI = URI.replace('/signalk/v1/api', '')
     }
 
     debug(`[fetch] ${opts.method || 'GET'} ${URI} ${JSON.stringify(opts, null, 2)}`)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,7 +72,7 @@ module.exports = {
         target: 'ws://localhost:3000',
         ws: true
       },
-      '/loginStatus': {
+      '/skServer/loginStatus': {
         target: 'http://localhost:3000',
       },
       '/signalk/': {


### PR DESCRIPTION
Avoid server log message "/loginStatus is deprecated, try updating webapps to the latest version"