### PR TITLE
fix: avoid hideLabel checkbox switch from uncontrolled to controlled

### DIFF
--- a/lib/ui/widgets/basewidget.js
+++ b/lib/ui/widgets/basewidget.js
@@ -102,7 +102,7 @@ BaseWidget.prototype.getSettingsElementUnitOnly = function (pushCellChange) {
 const settingsPanelHideLabelOnly = (props) => {
   return (
     <div>
-      <Checkbox className='headerCbShow' checked={props.options.hideLabel} onChange={props.onHideLabelChange} >Hide label when menubar disappears&nbsp;</Checkbox>
+      <Checkbox className='headerCbShow' checked={props.options.hideLabel || false} onChange={props.onHideLabelChange} >Hide label when menubar disappears&nbsp;</Checkbox>
     </div>
   )
 }
@@ -173,17 +173,17 @@ BaseWidget.prototype.setDelete = function (value) {
 }
 
 BaseWidget.prototype.defaultPostConversion = function (value, decimals) {
-  if(typeof value === 'number') {
-    if (typeof decimals !== 'undefined' && (parseInt(decimals) || decimals === '0')){
+  if (typeof value === 'number') {
+    if (typeof decimals !== 'undefined' && (parseInt(decimals) || decimals === '0')) {
       return value.toFixed(parseInt(decimals));
     }
     if (isNaN(value)) return '-';
 
     var v = Math.abs(value);
 
-    if(v >= 50) {
+    if (v >= 50) {
       return value.toFixed(0);
-    } else if(v >= 10) {
+    } else if (v >= 10) {
       return value.toFixed(1);
     } else {
       return value.toFixed(2);


### PR DESCRIPTION
fix: avoid hideLabel checkbox react component switch from uncontrolled to controlled